### PR TITLE
new syntax for yq and docker-compose

### DIFF
--- a/src/labctl.bash
+++ b/src/labctl.bash
@@ -124,14 +124,14 @@ _labctl_buildComposeFile() {
 
     # Generate volume list.
     volumes_tmp_file="$(mktemp)"
-    volumes="$(yq '.services | .[] | .volumes'\
-        "${working_dir}/docker-compose.yml" -crM\
-        | tr -d '\["\]' | cut -d ':' -f 1 | sed '/^null$/d')"
+    volumes="$(yq eval '.services | .[] | .volumes'\
+        "${working_dir}/docker-compose.yml"  \
+        | tr -d '\["\]' | cut -d ':' -f 1 | sed '/^null$/d' | cut -c 2- )"
 
     printf '%s\n' 'volumes:' > "${volumes_tmp_file}"
 
-    while read -r volume; do 
-        printf '  %s:\n' "${volume}" >> "${volumes_tmp_file}"
+    while read -r volume; do
+        printf '  %s: {}\n' "${volume}" >> "${volumes_tmp_file}"
     done <<<"${volumes}"
 
     # Add volume list to docker-compose.yml.


### PR DESCRIPTION
using latest yq and docker-compose lab.sh doesn't work. yq now needs to be run with an 'e' or 'eval' argument and docker-compose wants volumes defined without the leading dash and with {} after the volume name (i think).  